### PR TITLE
add support for more Unix-like OSes

### DIFF
--- a/vty-crossplatform.cabal
+++ b/vty-crossplatform.cabal
@@ -34,6 +34,10 @@ library
         build-depends:  vty-unix
     elif os(linux)
         build-depends:  vty-unix
+    elif os(freebsd) || os(openbsd) || os(netbsd) || os(dragonfly)
+        build-depends:  vty-unix
+    elif os(solaris) || os(aix) || os(hupx) || os(irix) || os(hurd)
+        build-depends:  vty-unix
     elif os(windows)
         build-depends:  vty-windows
     else


### PR DESCRIPTION
Support a bunch of other Unix-like operating systems, i.e. those which are recognised by cabal-install per
https://hackage.haskell.org/package/Cabal-syntax-3.10.2.0/docs/Distribution-System.html.

Whilst some of these are esoteric or aged, others - such as FreeBSD and OpenBSD - are in wide use.